### PR TITLE
Adds the `component` function to the nunjuck views

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,22 @@ if (process.env.NODE_ENV === 'development') {
 };
 
 var nunjucksEnv = nunjucks.configure("views", {
-  autoescape: true,
+  autoescape: false,
   express: app
 });
+
+/*
+ * Adds the function `component(partial)` to use globally in all templates
+ * Is an alias for:
+ * {% set component = partial %}
+ * {% include "partial/example.html" %}
+*/
+nunjucksEnv.addGlobal('component', function(component){
+  return nunjucks.render('partial/example.html', {
+    component: component
+  });
+});
+
 markdown.register(nunjucksEnv, marked);
 
 app.set('view engine', 'html');

--- a/views/markdown/navigation.md
+++ b/views/markdown/navigation.md
@@ -10,8 +10,7 @@ The components included in this section are intended to make easier to the user 
 
 A simple pagination element. If there are too many pages you can show just the pages that make sense the most. To highlight a page add to the link the class `.is-active`.
 
-{% set component = "components/pagination/default.html" %}
-{% include "partial/example.html" %}
+{{ component('components/pagination/default.html') }}
 
 ## Breadcrumbs
 
@@ -21,47 +20,44 @@ The breadcrumb is intended to make easier the navigation for the user. It shows 
 
 This flavor is shown in Socialbro's dashboard and it's the most important. Apart from showing a breadcrumb it has buttons to change filtering options or a specific step of it.
 
-{% set component = "components/breadcrumb/dashboard.html" %}
-{% include "partial/example.html" %}
+{{ component('components/breadcrumb/dashboard.html') }}
 
 ### Default
 
 The default breadcrumb is intended to use when there is not too much space and it's pretty much a classic breadcrumb. It just shows a path to make easier the navigation to previous pages.
 
-{% set component = "components/breadcrumb/default.html" %}
-{% include "partial/example.html" %}
+{{ component('components/breadcrumb/default.html') }}
+
 
 ### Simple
 
 The simple breadcrumb is used in the same context that the default but with simpler styling.
 
-{% set component = "components/breadcrumb/simple.html" %}
-{% include "partial/example.html" %}
+{{ component('components/breadcrumb/simple.html') }}
+
 
 ## Tabs
 
 When you need to toggle between different views, consider using tabs. We have different variants depending on the style and alignment of them. By default the tabs text is aligned to left and coming as a block filling the whole element width. You can set an active tab by using `.sb-tab-active` class.
 
-{% set component = "components/tabs/default.html" %}
-{% include "partial/example.html" %}
+{{ component('components/tabs/default.html') }}
 
 ### Tabs block bottom, text align center
 
 To align the tabs at the bottom you need to invert the declaration order with the content and add a class modifier `.sb-tabs--block-bottom`. To center the text tabs you can add the class `align-center` to the `.sb-tabs-group`.
 
-{% set component = "components/tabs/bottom-center.html" %}
-{% include "partial/example.html" %}
+{{ component('components/tabs/bottom-center.html') }}
 
 ### Tabs block on left
 
 Another variant is to have the tabs floating to the left instead of filling the whole width. You can use the modifier `.sb-tabs--block-left` to have them on left.
 
-{% set component = "components/tabs/block-left.html" %}
-{% include "partial/example.html" %}
+{{ component('components/tabs/block-left.html') }}
+
 
 ### Tabs block on right
 
 Similar to the previous one but the tabs float to the right in this case. You can get it with `.sb-tabs--block-right`.
 
-{% set component = "components/tabs/block-right.html" %}
-{% include "partial/example.html" %}
+{{ component('components/tabs/block-right.html') }}
+

--- a/views/markdown/typography.md
+++ b/views/markdown/typography.md
@@ -6,5 +6,4 @@ Here we will be grouping all elements directly related to typography. They are n
 
 We have style for the six different headings with different sizes each; except for the `h6` heading that has the same size as the `h5` but with lighter color.
 
-{% set component = "partial/headings.html" %}
-{% include "partial/example.html" %}
+{{ component('partial/headings.html') }}


### PR DESCRIPTION
This PR improves the way to include a component into the documentation views.

Instead of:

```
{% set component = "path/to/component" %}
{% include "partial/example.html" %}
```

You can use:

```
{{ component('path/to/component') }}
```
