### PR TITLE
Add tables component

### DIFF
--- a/sass/styleguide/objects/_tables.scss
+++ b/sass/styleguide/objects/_tables.scss
@@ -1,0 +1,75 @@
+$border-color: color($name: "text", $variant: "secondary", $hue: "light");
+$numerals: "first" "second" "third" "fourth" "fifth" "sixth" "seventh" "eigth" "ninth";
+
+.table {
+    border-collapse: separate;
+    border-radius: 4px;
+    border: 1px solid $border-color;
+    display: table;
+    overflow: hidden;
+}
+
+.table-heading {
+    background-color: color($name: "background");
+    color: color($name: "titles", $hue: "dark");
+    display: table-row;
+    font-weight: bold;
+    height: 6rem;
+    line-height: 1;
+    text-transform: uppercase;
+
+    .table-cell {
+        border-bottom: 1px solid $border-color;
+    }
+}
+
+.table-row {
+    background-color: color($name: "service", $variant: "tertiary", $hue: "light");
+    display: table-row;
+    height: 6rem;
+
+    &:nth-child(2n+1) {
+        background-color: color($name: "background", $hue: "light");
+    }
+}
+
+.table-cell {
+    display: table-cell;
+    padding: 1.5rem;
+    vertical-align: middle;
+
+    &:not(:last-child) {
+        border-right: 1px solid $border-color;
+    }
+}
+
+.table-cell-title, .table-cell-subtitle {
+    display: block;
+}
+
+.table-cell-subtitle {
+    color: color($name: "text");
+    font-weight: normal;
+    text-transform: none;
+}
+
+@for $i from 1 through length($numerals) {
+    .#{nth($numerals, $i)}-highlight {
+        .table-heading .table-cell:nth-child(#{$i}) {
+            background-color: color($name: "primary");
+            color: color($name: "background", $hue: "light");
+
+            .table-cell-subtitle {
+                color: color($name: "background", $hue: "light");
+            }
+        }
+
+        .table-cell:nth-child(#{$i}) {
+            background-color: lighten(color($name: "primary", $variant: "secondary", $hue: "light"), 2.5%);
+        }
+
+        .table-row:nth-child(2n+1) .table-cell:nth-child(#{$i}) {
+            background-color: lighten(color($name: "primary", $variant: "secondary", $hue: "light"), 7.5%);
+        }
+    }
+}

--- a/sass/styleguide/sandbox.scss
+++ b/sass/styleguide/sandbox.scss
@@ -66,6 +66,7 @@ This library is divided in the following sections:
 @import "objects/media";
 @import "objects/justify-columns";
 @import "objects/tabs";
+@import "objects/tables";
 @import "objects/pagination";
 @import "objects/breadcrumb";
 @import "objects/dropdown-toggler";

--- a/views/components/tables/simple-table.html
+++ b/views/components/tables/simple-table.html
@@ -1,0 +1,26 @@
+<table class="table third-highlight one-whole">
+  <tr class="table-heading">
+    <th class="table-cell">
+      <span class="table-cell-title">Double line</span>
+      <span class="table-cell-title">Text header</span>
+    </th>
+    <th class="table-cell">Number/Date</th>
+    <th class="table-cell">
+      <span class="table-cell-title">Double line</span>
+      <span class="table-cell-subtitle">Text with subtitle</span>
+    </th>
+    <th class="table-cell">Phrase</th>
+  </tr>
+  <tr class="table-row">
+    <td class="table-cell">Text content</td>
+    <td class="table-cell align-center">100%</td>
+    <td class="table-cell">Delete?</td>
+    <td class="table-cell">It's not done until it ships</td>
+  </tr>
+  <tr class="table-row">
+    <td class="table-cell"><a href="#">Text link and content</a></td>
+    <td class="table-cell  align-center">1985.19</td>
+    <td class="table-cell">Saved!</td>
+    <td class="table-cell">Get shipping done</td>
+  </tr>
+</table>

--- a/views/markdown/tables.md
+++ b/views/markdown/tables.md
@@ -1,0 +1,5 @@
+# Tables
+
+We have a simple table design that accepts some modifiers to build more complex. The content is, by default, aligned to the left but you can use generic helpers to change the alignment. In the example, the second column is centered with `align-center` helper class. There are also modifiers specific for the table component. You can highlight a column adding a `numeral-highlight` class to the table as seen in the example. If you want to use composed titles you can use `.table-cell-title` and `.table-cell-subtitle` classes.
+
+{{ component('components/tables/simple-table.html') }}

--- a/views/partial/menu.html
+++ b/views/partial/menu.html
@@ -3,6 +3,7 @@
     <a class="menu-item {% if section == 'colors' %}selected{% endif %}" href="/docs/colors">Colors</a>
     <a class="menu-item {% if section == 'icons' %}selected{% endif %}" href="/docs/icons">Icons</a>
     <a class="menu-item {% if section == 'navigation' %}selected{% endif %}" href="/docs/navigation">Navigation</a>
+    <a class="menu-item {% if section == 'tables' %}selected{% endif %}" href="/docs/tables">Tables</a>
     <a class="menu-item {% if section == 'typography' %}selected{% endif %}" href="/docs/typography">Typography</a>
   </nav>
 </div>


### PR DESCRIPTION
Adds a `table` component. Because I'm not sure about the section where the component should be included, for now I've added a new section called **tables**. Following the Sketch styleguide we just have one table component the can be modified.

Main modification is to highlight a column and I've added a group of classes to write a class and style a whole column, ie `third-highlight`. This is not usual and that's why it's commented here. Another modification is about headers but not a big deal.
